### PR TITLE
🧪 [Fix notebook syntax errors and add automated syntax validation]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,9 @@ fastlane/Preview.html
 fastlane/screenshots
 fastlane/test_output
 fastlane/readme.md
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+.pytest_cache/

--- a/quickstarts/Get_started.ipynb
+++ b/quickstarts/Get_started.ipynb
@@ -2675,14 +2675,9 @@
       ]
     },
     {
-      "cell_type": "code",
+      "cell_type": "markdown",
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 141
-        },
-        "id": "d2d58776",
-        "outputId": "466565bd-9b7d-433d-a298-260eeae8a0af"
+        "id": "d2d58776"
       },
       "source": [
         "## Framework Design - Self-Ports & Multi-Self Ports\n",
@@ -2696,17 +2691,6 @@
         "3. Detail the technical design for Multi-Self Ports, explaining how they aggregate, abstract, or orchestrate communication between multiple Self-Ports, and how they facilitate dynamic routing and negotiation of data exchange across different models or services.\n",
         "4. Describe the self-configuration and adaptive mechanisms enabled by these ports, such as automatic connection establishment, capability negotiation, and dynamic routing based on system state or context awareness.\n",
         "5. Discuss how these ports interact with the previously defined 'Multi Self-Context Context Protocol' and 'Multi-Route Context Protocol' to leverage shared context for intelligent communication and adaptation."
-      ],
-      "execution_count": 10,
-      "outputs": [
-        {
-          "output_type": "error",
-          "ename": "SyntaxError",
-          "evalue": "invalid syntax (ipython-input-3460130946.py, line 4)",
-          "traceback": [
-            "\u001b[0;36m  File \u001b[0;32m\"/tmp/ipython-input-3460130946.py\"\u001b[0;36m, line \u001b[0;32m4\u001b[0m\n\u001b[0;31m    Develop the conceptual and technical design for 'new framework self-ports and multi-self ports' to enable dynamic and adaptive inter-component communication and self-configuration within the system.\u001b[0m\n\u001b[0m            ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid syntax\n"
-          ]
-        }
       ]
     },
     {
@@ -2721,14 +2705,9 @@
       ]
     },
     {
-      "cell_type": "code",
+      "cell_type": "markdown",
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 141
-        },
-        "id": "ed81f45f",
-        "outputId": "16240ab2-997f-4a7a-a197-d55d434ff61f"
+        "id": "ed81f45f"
       },
       "source": [
         "## Framework Design - Self-Ports & Multi-Self Ports\n",
@@ -2742,17 +2721,6 @@
         "3. Detail the technical design for Multi-Self Ports, explaining how they aggregate, abstract, or orchestrate communication between multiple Self-Ports, and how they facilitate dynamic routing and negotiation of data exchange across different models or services.\n",
         "4. Describe the self-configuration and adaptive mechanisms enabled by these ports, such as automatic connection establishment, capability negotiation, and dynamic routing based on system state or context awareness.\n",
         "5. Discuss how these ports interact with the previously defined 'Multi Self-Context Context Protocol' and 'Multi-Route Context Protocol' to leverage shared context for intelligent communication and adaptation."
-      ],
-      "execution_count": 11,
-      "outputs": [
-        {
-          "output_type": "error",
-          "ename": "SyntaxError",
-          "evalue": "invalid syntax (ipython-input-3460130946.py, line 4)",
-          "traceback": [
-            "\u001b[0;36m  File \u001b[0;32m\"/tmp/ipython-input-3460130946.py\"\u001b[0;36m, line \u001b[0;32m4\u001b[0m\n\u001b[0;31m    Develop the conceptual and technical design for 'new framework self-ports and multi-self ports' to enable dynamic and adaptive inter-component communication and self-configuration within the system.\u001b[0m\n\u001b[0m            ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid syntax\n"
-          ]
-        }
       ]
     },
     {
@@ -2767,14 +2735,9 @@
       ]
     },
     {
-      "cell_type": "code",
+      "cell_type": "markdown",
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 141
-        },
-        "id": "76bf49b3",
-        "outputId": "ee6d80a2-bc8f-4af4-c905-bf9ab845daaa"
+        "id": "76bf49b3"
       },
       "source": [
         "## Framework Design - Self-Ports & Multi-Self Ports\n",
@@ -2788,17 +2751,6 @@
         "3. Detail the technical design for Multi-Self Ports, explaining how they aggregate, abstract, or orchestrate communication between multiple Self-Ports, and how they facilitate dynamic routing and negotiation of data exchange across different models or services.\n",
         "4. Describe the self-configuration and adaptive mechanisms enabled by these ports, such as automatic connection establishment, capability negotiation, and dynamic routing based on system state or context awareness.\n",
         "5. Discuss how these ports interact with the previously defined 'Multi Self-Context Context Protocol' and 'Multi-Route Context Protocol' to leverage shared context for intelligent communication and adaptation."
-      ],
-      "execution_count": 12,
-      "outputs": [
-        {
-          "output_type": "error",
-          "ename": "SyntaxError",
-          "evalue": "invalid syntax (ipython-input-3460130946.py, line 4)",
-          "traceback": [
-            "\u001b[0;36m  File \u001b[0;32m\"/tmp/ipython-input-3460130946.py\"\u001b[0;36m, line \u001b[0;32m4\u001b[0m\n\u001b[0;31m    Develop the conceptual and technical design for 'new framework self-ports and multi-self ports' to enable dynamic and adaptive inter-component communication and self-configuration within the system.\u001b[0m\n\u001b[0m            ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid syntax\n"
-          ]
-        }
       ]
     },
     {
@@ -2813,14 +2765,9 @@
       ]
     },
     {
-      "cell_type": "code",
+      "cell_type": "markdown",
       "metadata": {
-        "colab": {
-          "base_uri": "https://localhost:8080/",
-          "height": 141
-        },
-        "id": "46204861",
-        "outputId": "c3092dae-6364-43fa-bf80-56909f2efef5"
+        "id": "46204861"
       },
       "source": [
         "## Framework Design - Self-Ports & Multi-Self Ports\n",
@@ -2834,17 +2781,6 @@
         "3. Detail the technical design for Multi-Self Ports, explaining how they aggregate, abstract, or orchestrate communication between multiple Self-Ports, and how they facilitate dynamic routing and negotiation of data exchange across different models or services.\n",
         "4. Describe the self-configuration and adaptive mechanisms enabled by these ports, such as automatic connection establishment, capability negotiation, and dynamic routing based on system state or context awareness.\n",
         "5. Discuss how these ports interact with the previously defined 'Multi Self-Context Context Protocol' and 'Multi-Route Context Protocol' to leverage shared context for intelligent communication and adaptation."
-      ],
-      "execution_count": 13,
-      "outputs": [
-        {
-          "output_type": "error",
-          "ename": "SyntaxError",
-          "evalue": "invalid syntax (ipython-input-3460130946.py, line 4)",
-          "traceback": [
-            "\u001b[0;36m  File \u001b[0;32m\"/tmp/ipython-input-3460130946.py\"\u001b[0;36m, line \u001b[0;32m4\u001b[0m\n\u001b[0;31m    Develop the conceptual and technical design for 'new framework self-ports and multi-self ports' to enable dynamic and adaptive inter-component communication and self-configuration within the system.\u001b[0m\n\u001b[0m            ^\u001b[0m\n\u001b[0;31mSyntaxError\u001b[0m\u001b[0;31m:\u001b[0m invalid syntax\n"
-          ]
-        }
       ]
     }
   ],

--- a/tests/test_notebook_syntax.py
+++ b/tests/test_notebook_syntax.py
@@ -1,0 +1,60 @@
+import json
+import ast
+import glob
+import pytest
+
+def test_notebook_code_cells_syntax():
+    notebooks = glob.glob("quickstarts/*.ipynb")
+    assert notebooks, "No notebooks found in quickstarts/"
+
+    errors = []
+    for nb_path in notebooks:
+        with open(nb_path, "r", encoding="utf-8") as f:
+            nb = json.load(f)
+
+        for i, cell in enumerate(nb.get("cells", [])):
+            if cell.get("cell_type") == "code":
+                source = "".join(cell.get("source", []))
+                if not source.strip():
+                    continue
+
+                # Check for SyntaxError in outputs
+                outputs = cell.get("outputs", [])
+                has_recorded_syntax_error = False
+                for output in outputs:
+                    if output.get("output_type") == "error" and output.get("ename") == "SyntaxError":
+                        has_recorded_syntax_error = True
+                        break
+
+                # Validate Python syntax
+                lines = cell.get("source", [])
+                python_lines = []
+                for line in lines:
+                    stripped = line.lstrip()
+                    if stripped.startswith(("%", "!")):
+                        # Simple heuristic for IPython magics and shell commands
+                        continue
+                    python_lines.append(line)
+
+                python_code = "".join(python_lines)
+                # Further cleaning: some cells might have inline magics or other things,
+                # but ast.parse is a good baseline.
+
+                syntax_error = None
+                if python_code.strip():
+                    try:
+                        ast.parse(python_code)
+                    except SyntaxError as e:
+                        syntax_error = e
+
+                if has_recorded_syntax_error or syntax_error:
+                    error_msg = f"Cell {i} in {nb_path} has issues:\n"
+                    if has_recorded_syntax_error:
+                        error_msg += "  - Has a recorded SyntaxError in its outputs.\n"
+                    if syntax_error:
+                        error_msg += f"  - Python syntax error: {syntax_error}\n"
+                    error_msg += f"Source snippet: {source[:100]}..."
+                    errors.append(error_msg)
+
+    if errors:
+        pytest.fail("\n".join(errors))


### PR DESCRIPTION
This pull request fixes a regression in `quickstarts/Get_started.ipynb` where several markdown-heavy cells were incorrectly typed as `code`, leading to syntax errors during execution. 

Key changes:
- Converted 4 problematic cells in `Get_started.ipynb` from `code` to `markdown`.
- Cleaned up execution artifacts (`outputs`, `execution_count`) and Colab-specific metadata from the fixed cells.
- Introduced `tests/test_notebook_syntax.py`, which uses `ast.parse` and output inspection to ensure all notebooks in `quickstarts/` are syntactically valid.
- Updated `.gitignore` to include standard Python ignore patterns.
- Preserved the repository's 2-space indentation and non-ASCII character encoding in the notebook JSON.

The new test successfully identified the issues before the fix and passes after the changes.

---
*PR created automatically by Jules for task [13905709721626386963](https://jules.google.com/task/13905709721626386963) started by @jason420247*