### PR TITLE
⚡ [optimize MicrotubuleTorus rendering with InstancedMesh]

### DIFF
--- a/components/QuantumScene.tsx
+++ b/components/QuantumScene.tsx
@@ -1,0 +1,74 @@
+import React, { useMemo, useRef } from "react";
+import { useFrame } from "@react-three/fiber";
+import * as THREE from "three";
+
+/**
+ * MicrotubuleTorus models hypothesized quantum-coherent structures within neurons.
+ * This component is optimized using InstancedMesh to minimize draw calls.
+ */
+const MicrotubuleTorus = ({
+  radius,
+  count = 360,
+  offset = 0,
+  color = "#C5A059",
+  speed = 1,
+}: {
+  radius: number;
+  count?: number;
+  offset?: number;
+  color?: string;
+  speed?: number;
+}) => {
+  const meshRef = useRef<THREE.InstancedMesh>(null);
+  const tempObject = useMemo(() => new THREE.Object3D(), []);
+
+  const cubes = useMemo(() => {
+    const arr = [];
+    for (let i = 0; i < count; i++) {
+      const angle = (i / count) * Math.PI * 2 + offset;
+      const x = Math.cos(angle) * radius;
+      const y = Math.sin(angle) * radius;
+      arr.push({ x, y, angle });
+    }
+    return arr;
+  }, [radius, count, offset]);
+
+  useFrame((state) => {
+    if (!meshRef.current) return;
+
+    const time = state.clock.getElapsedTime() * speed;
+
+    for (let i = 0; i < cubes.length; i++) {
+      const cube = cubes[i];
+      tempObject.position.set(cube.x, cube.y, Math.sin(time + i * 0.1) * 0.2);
+      tempObject.rotation.set(0, 0, cube.angle + time);
+      tempObject.updateMatrix();
+      meshRef.current.setMatrixAt(i, tempObject.matrix);
+    }
+    meshRef.current.instanceMatrix.needsUpdate = true;
+  });
+
+  return (
+    <instancedMesh ref={meshRef} args={[undefined, undefined, count]}>
+      <boxGeometry args={[0.1, 0.1, 0.1]} />
+      <meshStandardMaterial color={color} />
+    </instancedMesh>
+  );
+};
+
+export const QuantumScene = () => {
+  return (
+    <group>
+      <ambientLight intensity={0.5} />
+      <pointLight position={[10, 10, 10]} />
+      <MicrotubuleTorus radius={5} count={360} color="#C5A059" speed={1} />
+      <MicrotubuleTorus
+        radius={10}
+        count={720}
+        offset={Math.PI}
+        color="#E5C079"
+        speed={0.5}
+      />
+    </group>
+  );
+};


### PR DESCRIPTION
💡 **What:** The optimization implemented
- Refactored `MicrotubuleTorus` to use `THREE.InstancedMesh` for rendering.
- Replaced individual mesh mapping with a single `instancedMesh` component.
- Used a reusable `THREE.Object3D` instance in the `useFrame` loop for matrix updates.
- Ensured the `offset` prop is correctly used in the angle calculation.

🎯 **Why:** The performance problem it solves
- Rendering 1080 individual meshes (360 + 720 from two torus instances) results in 1080 draw calls per frame, which is extremely expensive for the GPU.
- Individual mesh creation and management in React increases scene graph complexity and memory overhead.

📊 **Measured Improvement:**
- **Theoretical Improvement:** Reduced draw calls from 1080 to 2 for the toruses in the scene.
- **Memory Efficiency:** Eliminated per-frame object allocations for matrix updates by using a reusable `Object3D`, reducing garbage collection pressure.
- **Scene Graph:** Simplified the scene graph by replacing 1080 mesh nodes with 2 `InstancedMesh` nodes.

---
*PR created automatically by Jules for task [14928936104551388551](https://jules.google.com/task/14928936104551388551) started by @jason420247*