### PR TITLE
⚡ Optimize MicrotubuleTorus rendering with InstancedMesh

### DIFF
--- a/components/QuantumScene.tsx
+++ b/components/QuantumScene.tsx
@@ -1,0 +1,78 @@
+import React, { useMemo, useRef } from "react";
+import { useFrame } from "@react-three/fiber";
+import * as THREE from "three";
+
+/**
+ * MicrotubuleTorus models hypothesized quantum-coherent structures within neurons.
+ * This component is optimized using InstancedMesh to minimize draw calls.
+ */
+const MicrotubuleTorus = ({
+  radius,
+  count = 360,
+  offset = 0,
+  color = "#C5A059",
+  speed = 1,
+}: {
+  radius: number;
+  count?: number;
+  offset?: number;
+  color?: string;
+  speed?: number;
+}) => {
+  const meshRef = useRef<THREE.InstancedMesh>(null);
+  const tempObject = useMemo(() => new THREE.Object3D(), []);
+
+  const cubes = useMemo(() => {
+    const arr = [];
+    for (let i = 0; i < count; i++) {
+      const angle = (i / count) * Math.PI * 2 + offset;
+      const x = Math.cos(angle) * radius;
+      const y = Math.sin(angle) * radius;
+      arr.push({ x, y, angle });
+    }
+    return arr;
+  }, [radius, count, offset]);
+
+  useFrame((state) => {
+    if (!meshRef.current) return;
+
+    const time = state.clock.getElapsedTime() * speed;
+
+    for (let i = 0; i < cubes.length; i++) {
+      const cube = cubes[i];
+      tempObject.position.set(cube.x, cube.y, Math.sin(time + i * 0.1) * 0.2);
+      tempObject.rotation.set(0, 0, cube.angle + time);
+      tempObject.updateMatrix();
+      meshRef.current.setMatrixAt(i, tempObject.matrix);
+    }
+    meshRef.current.instanceMatrix.needsUpdate = true;
+  });
+
+  return (
+    <instancedMesh
+      ref={meshRef}
+      args={[undefined, undefined, count]}
+      frustumCulled={false}
+    >
+      <boxGeometry args={[0.1, 0.1, 0.1]} />
+      <meshStandardMaterial color={color} />
+    </instancedMesh>
+  );
+};
+
+export const QuantumScene = () => {
+  return (
+    <group>
+      <ambientLight intensity={0.5} />
+      <pointLight position={[10, 10, 10]} />
+      <MicrotubuleTorus radius={5} count={360} color="#C5A059" speed={1} />
+      <MicrotubuleTorus
+        radius={10}
+        count={720}
+        offset={Math.PI}
+        color="#E5C079"
+        speed={0.5}
+      />
+    </group>
+  );
+};


### PR DESCRIPTION
💡 **What:** The optimization implemented
- Refactored the `MicrotubuleTorus` component in `QuantumScene.tsx` to use `THREE.InstancedMesh`.
- Utilized a reusable `THREE.Object3D` instance for efficient matrix updates within the `useFrame` animation loop.
- Set `frustumCulled={false}` on the `InstancedMesh` to ensure consistent visibility of the microtubules.

🎯 **Why:** The performance problem it solves
- Rendering thousands of individual meshes (360 and 720 for the two toruses) is extremely expensive due to the overhead of a large number of draw calls.
- Switching to `InstancedMesh` allows all instances of the same geometry and material to be rendered in a single draw call per torus.

📊 **Measured Improvement:**
- Theoretical reduction in draw calls from 1,080 to 2 for the `MicrotubuleTorus` components.
- Improved CPU performance and reduced garbage collection pressure by reusing a single `Object3D` for matrix calculations instead of creating new objects or updating thousands of individual React component states.

---
*PR created automatically by Jules for task [12980713994910691445](https://jules.google.com/task/12980713994910691445) started by @jason420247*