### PR TITLE
⚡ Optimize MicrotubuleTorus rendering with InstancedMesh

### DIFF
--- a/components/QuantumScene.tsx
+++ b/components/QuantumScene.tsx
@@ -1,0 +1,78 @@
+import React, { useMemo, useRef } from "react";
+import { useFrame } from "@react-three/fiber";
+import * as THREE from "three";
+
+/**
+ * MicrotubuleTorus models hypothesized quantum-coherent structures within neurons.
+ * This component is optimized using InstancedMesh to minimize draw calls.
+ */
+const MicrotubuleTorus = ({
+  radius,
+  count = 360,
+  offset = 0,
+  color = "#C5A059",
+  speed = 1,
+}: {
+  radius: number;
+  count?: number;
+  offset?: number;
+  color?: string;
+  speed?: number;
+}) => {
+  const meshRef = useRef<THREE.InstancedMesh>(null);
+  const tempObject = useMemo(() => new THREE.Object3D(), []);
+
+  const cubes = useMemo(() => {
+    const arr = [];
+    for (let i = 0; i < count; i++) {
+      const angle = (i / count) * Math.PI * 2 + offset;
+      const x = Math.cos(angle) * radius;
+      const y = Math.sin(angle) * radius;
+      arr.push({ x, y, angle });
+    }
+    return arr;
+  }, [radius, count, offset]);
+
+  useFrame((state) => {
+    if (!meshRef.current) return;
+
+    const time = state.clock.getElapsedTime() * speed;
+
+    for (let i = 0; i < cubes.length; i++) {
+      const cube = cubes[i];
+      tempObject.position.set(cube.x, cube.y, Math.sin(time + i * 0.1) * 0.2);
+      tempObject.rotation.set(0, 0, cube.angle + time);
+      tempObject.updateMatrix();
+      meshRef.current.setMatrixAt(i, tempObject.matrix);
+    }
+    meshRef.current.instanceMatrix.needsUpdate = true;
+  });
+
+  return (
+    <instancedMesh
+      ref={meshRef}
+      args={[undefined, undefined, count]}
+      frustumCulled={false}
+    >
+      <boxGeometry args={[0.1, 0.1, 0.1]} />
+      <meshStandardMaterial color={color} />
+    </instancedMesh>
+  );
+};
+
+export const QuantumScene = () => {
+  return (
+    <group>
+      <ambientLight intensity={0.5} />
+      <pointLight position={[10, 10, 10]} />
+      <MicrotubuleTorus radius={5} count={360} color="#C5A059" speed={1} />
+      <MicrotubuleTorus
+        radius={10}
+        count={720}
+        offset={Math.PI}
+        color="#E5C079"
+        speed={0.5}
+      />
+    </group>
+  );
+};


### PR DESCRIPTION
💡 **What:** The optimization implemented
- Replaced individual mesh components with `THREE.InstancedMesh` in the `MicrotubuleTorus` component.
- Used a reusable `THREE.Object3D` instance for efficient matrix updates in the `useFrame` loop.
- Added `frustumCulled={false}` to ensure instances remain visible during animations.

🎯 **Why:** The performance problem it solves
- Rendering thousands of individual meshes in a React Three Fiber scene causes excessive draw calls, which leads to CPU bottlenecks and poor frame rates.
- Using `InstancedMesh` allows the GPU to render many identical geometries in a single draw call.

📊 **Measured Improvement:**
- **Theoretical Improvement:** Reduced draw calls from **1,080** (360 + 720 individual meshes for the two toruses) to **2** (one for each `InstancedMesh`).
- This significantly reduces the CPU overhead for scene graph traversal and state changes in the renderer.
- **Note:** Direct performance profiling was impractical due to the lack of a local development server and `package.json` infrastructure in the repository environment. The optimization follows standard WebGL and Three.js performance best practices.

---
*PR created automatically by Jules for task [6601276833230247742](https://jules.google.com/task/6601276833230247742) started by @jason420247*