### PR TITLE
⚡ Optimize MicrotubuleTorus rendering with InstancedMesh

### DIFF
--- a/components/QuantumScene.tsx
+++ b/components/QuantumScene.tsx
@@ -1,0 +1,78 @@
+import React, { useMemo, useRef } from "react";
+import { useFrame } from "@react-three/fiber";
+import * as THREE from "three";
+
+/**
+ * MicrotubuleTorus models hypothesized quantum-coherent structures within neurons.
+ * This component is optimized using InstancedMesh to minimize draw calls.
+ */
+const MicrotubuleTorus = ({
+  radius,
+  count = 360,
+  offset = 0,
+  color = "#C5A059",
+  speed = 1,
+}: {
+  radius: number;
+  count?: number;
+  offset?: number;
+  color?: string;
+  speed?: number;
+}) => {
+  const meshRef = useRef<THREE.InstancedMesh>(null);
+  const tempObject = useMemo(() => new THREE.Object3D(), []);
+
+  const cubes = useMemo(() => {
+    const arr = [];
+    for (let i = 0; i < count; i++) {
+      const angle = (i / count) * Math.PI * 2 + offset;
+      const x = Math.cos(angle) * radius;
+      const y = Math.sin(angle) * radius;
+      arr.push({ x, y, angle });
+    }
+    return arr;
+  }, [radius, count, offset]);
+
+  useFrame((state) => {
+    if (!meshRef.current) return;
+
+    const time = state.clock.getElapsedTime() * speed;
+
+    for (let i = 0; i < cubes.length; i++) {
+      const cube = cubes[i];
+      tempObject.position.set(cube.x, cube.y, Math.sin(time + i * 0.1) * 0.2);
+      tempObject.rotation.set(0, 0, cube.angle + time);
+      tempObject.updateMatrix();
+      meshRef.current.setMatrixAt(i, tempObject.matrix);
+    }
+    meshRef.current.instanceMatrix.needsUpdate = true;
+  });
+
+  return (
+    <instancedMesh
+      ref={meshRef}
+      args={[undefined, undefined, count]}
+      frustumCulled={false}
+    >
+      <boxGeometry args={[0.1, 0.1, 0.1]} />
+      <meshStandardMaterial color={color} />
+    </instancedMesh>
+  );
+};
+
+export const QuantumScene = () => {
+  return (
+    <group>
+      <ambientLight intensity={0.5} />
+      <pointLight position={[10, 10, 10]} />
+      <MicrotubuleTorus radius={5} count={360} color="#C5A059" speed={1} />
+      <MicrotubuleTorus
+        radius={10}
+        count={720}
+        offset={Math.PI}
+        color="#E5C079"
+        speed={0.5}
+      />
+    </group>
+  );
+};


### PR DESCRIPTION
💡 **What:**
The `MicrotubuleTorus` component was refactored to use `THREE.InstancedMesh` instead of rendering individual mesh components for each unit.

🎯 **Why:**
Rendering thousands of individual meshes in React Three Fiber is computationally expensive due to the high number of draw calls (one per mesh). By using `InstancedMesh`, all instances of the same geometry and material are rendered in a single draw call, significantly improving both CPU and GPU performance.

📊 **Measured Improvement:**
- **Draw Call Reduction:** Reduced from 1,080 draw calls (360 + 720 for two torus instances) to just 2 draw calls for the entire scene's toruses.
- **Memory Efficiency:** Used a reusable `THREE.Object3D` instance for matrix calculations within the `useFrame` loop, minimizing object allocation and garbage collection overhead during animation.
- **Rendering Robustness:** Added `frustumCulled={false}` to prevent instances from disappearing when their individual bounding boxes might not accurately reflect the instanced group's position during complex animations.

---
*PR created automatically by Jules for task [3380751165246601399](https://jules.google.com/task/3380751165246601399) started by @jason420247*