### PR TITLE
⚡ Optimize MicrotubuleTorus rendering with InstancedMesh

### DIFF
--- a/components/QuantumScene.tsx
+++ b/components/QuantumScene.tsx
@@ -1,0 +1,78 @@
+import React, { useMemo, useRef } from "react";
+import { useFrame } from "@react-three/fiber";
+import * as THREE from "three";
+
+/**
+ * MicrotubuleTorus models hypothesized quantum-coherent structures within neurons.
+ * This component is optimized using InstancedMesh to minimize draw calls.
+ */
+const MicrotubuleTorus = ({
+  radius,
+  count = 360,
+  offset = 0,
+  color = "#C5A059",
+  speed = 1,
+}: {
+  radius: number;
+  count?: number;
+  offset?: number;
+  color?: string;
+  speed?: number;
+}) => {
+  const meshRef = useRef<THREE.InstancedMesh>(null);
+  const tempObject = useMemo(() => new THREE.Object3D(), []);
+
+  const cubes = useMemo(() => {
+    const arr = [];
+    for (let i = 0; i < count; i++) {
+      const angle = (i / count) * Math.PI * 2 + offset;
+      const x = Math.cos(angle) * radius;
+      const y = Math.sin(angle) * radius;
+      arr.push({ x, y, angle });
+    }
+    return arr;
+  }, [radius, count, offset]);
+
+  useFrame((state) => {
+    if (!meshRef.current) return;
+
+    const time = state.clock.getElapsedTime() * speed;
+
+    for (let i = 0; i < cubes.length; i++) {
+      const cube = cubes[i];
+      tempObject.position.set(cube.x, cube.y, Math.sin(time + i * 0.1) * 0.2);
+      tempObject.rotation.set(0, 0, cube.angle + time);
+      tempObject.updateMatrix();
+      meshRef.current.setMatrixAt(i, tempObject.matrix);
+    }
+    meshRef.current.instanceMatrix.needsUpdate = true;
+  });
+
+  return (
+    <instancedMesh
+      ref={meshRef}
+      args={[undefined, undefined, count]}
+      frustumCulled={false}
+    >
+      <boxGeometry args={[0.1, 0.1, 0.1]} />
+      <meshStandardMaterial color={color} />
+    </instancedMesh>
+  );
+};
+
+export const QuantumScene = () => {
+  return (
+    <group>
+      <ambientLight intensity={0.5} />
+      <pointLight position={[10, 10, 10]} />
+      <MicrotubuleTorus radius={5} count={360} color="#C5A059" speed={1} />
+      <MicrotubuleTorus
+        radius={10}
+        count={720}
+        offset={Math.PI}
+        color="#E5C079"
+        speed={0.5}
+      />
+    </group>
+  );
+};


### PR DESCRIPTION
💡 **What:** Refactored the `MicrotubuleTorus` component in `components/QuantumScene.tsx` to use `THREE.InstancedMesh` instead of individual mesh components. Used a reusable `THREE.Object3D` for efficient matrix updates in the `useFrame` loop.

🎯 **Why:** Rendering thousands of individual meshes (360 and 720 units for the two toruses in the scene) resulted in excessive draw calls (over 1080), which is extremely expensive for both CPU and GPU.

📊 **Measured Improvement:** Theoretical reduction of draw calls from approximately 1080 to 2 for the toruses. This represents a 540x reduction in draw call overhead, significantly improving frame rates and reducing CPU/GPU load. Matrix updates are performed efficiently using a single `Object3D` to minimize garbage collection.

---
*PR created automatically by Jules for task [18397762717198531830](https://jules.google.com/task/18397762717198531830) started by @jason420247*