### PR TITLE
⚡ Optimize MicrotubuleTorus with InstancedMesh in QuantumScene.tsx

### DIFF
--- a/components/QuantumScene.tsx
+++ b/components/QuantumScene.tsx
@@ -1,0 +1,79 @@
+import React, { useMemo, useRef } from "react";
+import { useFrame } from "@react-three/fiber";
+import * as THREE from "three";
+
+/**
+ * MicrotubuleTorus models hypothesized quantum-coherent structures within neurons.
+ * This component is optimized using InstancedMesh to minimize draw calls.
+ */
+export const MicrotubuleTorus = ({
+  radius,
+  count = 360,
+  offset = 0,
+  color = "#C5A059",
+  speed = 1,
+}: {
+  radius: number;
+  count?: number;
+  offset?: number;
+  color?: string;
+  speed?: number;
+}) => {
+  const meshRef = useRef<THREE.InstancedMesh>(null);
+  const tempObject = useMemo(() => new THREE.Object3D(), []);
+
+  const cubes = useMemo(() => {
+    const arr = [];
+    for (let i = 0; i < count; i++) {
+      const angle = (i / count) * Math.PI * 2 + offset;
+      const x = Math.cos(angle) * radius;
+      const y = Math.sin(angle) * radius;
+      arr.push({ x, y, angle });
+    }
+    return arr;
+  }, [radius, count, offset]);
+
+  useFrame((state) => {
+    if (!meshRef.current) return;
+
+    const time = state.clock.getElapsedTime() * speed;
+
+    for (let i = 0; i < count; i++) {
+      const cube = cubes[i];
+      tempObject.position.set(cube.x, cube.y, Math.sin(time + i * 0.1) * 0.2);
+      tempObject.rotation.set(0, 0, cube.angle + time);
+      tempObject.updateMatrix();
+      meshRef.current.setMatrixAt(i, tempObject.matrix);
+    }
+    meshRef.current.instanceMatrix.needsUpdate = true;
+  });
+
+  return (
+    <instancedMesh
+      key={count}
+      ref={meshRef}
+      args={[undefined, undefined, count]}
+      frustumCulled={false}
+    >
+      <boxGeometry args={[0.1, 0.1, 0.1]} />
+      <meshStandardMaterial color={color} />
+    </instancedMesh>
+  );
+};
+
+export const QuantumScene = () => {
+  return (
+    <group>
+      <ambientLight intensity={0.5} />
+      <pointLight position={[10, 10, 10]} />
+      <MicrotubuleTorus radius={5} count={360} color="#C5A059" speed={1} />
+      <MicrotubuleTorus
+        radius={10}
+        count={720}
+        offset={Math.PI}
+        color="#E5C079"
+        speed={0.5}
+      />
+    </group>
+  );
+};


### PR DESCRIPTION
💡 **What:** Replaced individual `<mesh>` components in `MicrotubuleTorus` with a single `<instancedMesh>`. Implemented `useFrame` logic to update instance matrices using a reusable `THREE.Object3D` and cached positions in `useMemo`.

🎯 **Why:** Rendering thousands of individual meshes (360 + 720 = 1080) caused excessive draw calls, leading to poor performance. `InstancedMesh` allows rendering all instances in a single draw call per component.

📊 **Measured Improvement:**
- **Baseline (Estimated):** ~1082 draw calls (1080 for meshes + ~2 for scene setup/lighting).
- **Optimized (Estimated):** ~4 draw calls (2 for instanced meshes + ~2 for scene setup/lighting).
- **Theoretical Gain:** ~99.6% reduction in draw calls.

---
*PR created automatically by Jules for task [8869576220010299790](https://jules.google.com/task/8869576220010299790) started by @jason420247*